### PR TITLE
Solve TypeError in django 1.11 and python3

### DIFF
--- a/imagecompressor/management/commands/compressimages.py
+++ b/imagecompressor/management/commands/compressimages.py
@@ -31,7 +31,7 @@ class Command(BaseCommand):
         except AttributeError:
             IMAGE_COMPRESS_ROOT = Path('IMAGES')
 
-        staticfiles_manifest_path = STATIC_ROOT / 'staticfiles.json'
+        staticfiles_manifest_path = str(STATIC_ROOT / 'staticfiles.json')
         images_directory = STATIC_ROOT / IMAGE_COMPRESS_ROOT
         search_path = STATIC_ROOT / options['path']
 


### PR DESCRIPTION
Django uses pathlib to store paths https://docs.python.org/3/library/pathlib.html
They provide an object oriented path manipulation (you do path.open() instead of open(path). 

This solves the problem without regression I think (if the path is already a string nothing will change, if it's a pathlib path, it will be casted to it's string value).